### PR TITLE
Add version mismatch warning and separate logging configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Dockyman reads a `dockyman.yaml` that describes a **swarm** of nodes (local or r
 - **Multiple env files** — pass several `--env-file` paths per node.
 - **Per-node setup script** — run arbitrary shell commands on each node before containers start (xrandr, pactl, env exports, etc.).
 - **Hardware detection** — collect system, CPU, memory, GPU, audio, USB, network, and disk info per node; save to a log file or stream to stdout.
-- **Per-service container logs** — saved as `<log_dir>/<node_id>/<service>.log`.
+- **Per-service container logs** — saved as `<container_log_dir>/<node_id>/<service>.log`.
 - **Dry-run mode** — preview every command without executing (`--dry-run`).
 
 ## Requirements
@@ -110,9 +110,9 @@ dockyman build
 The main command. It performs the following steps in order:
 
 1. **Run `setup_script`** on each node (silently — output is not shown).
-2. **Log node configuration and hardware info** to `<log_dir>/<node_id>/config.log` (if `log_dir` is set). The node configuration (compose files, env files, shell prefixes, etc.) is also printed to the console.
+2. **Log node configuration and hardware info** to `<config_log_dir>/<node_id>.log` (if `config_log_dir` is set). The node configuration (compose files, env files, shell prefixes, etc.) is also printed to the console.
 3. **Start containers** (`docker compose up -d`) on each node.
-4. **Stream container logs** to stdout, or to `<log_dir>/<node_id>/<service>.log` files if logging is configured.
+4. **Stream container logs** to stdout, or to `<container_log_dir>/<node_id>/<service>.log` files if logging is configured.
 5. **Wait** for the user to press ENTER.
 6. **Stop containers** (`docker compose down`) on each node.
 
@@ -125,7 +125,7 @@ dockyman run --log-output ./logs # override log directory for this run
 | Option | Description |
 |---|---|
 | `-d`, `--detach` | Start containers in the background and exit immediately. |
-| `--log-output DIR` | Save container logs to `DIR/<node_id>/<service>.log`. Overrides `log_dir` from `dockyman.yaml`. |
+| `--log-output DIR` | Save container logs to `DIR/<node_id>/<service>.log`. Overrides `container_log_dir` from `dockyman.yaml`. |
 
 ---
 
@@ -153,8 +153,8 @@ dockyman config
 
 Collect and display hardware information for each node: system/OS, CPU, memory, GPU/display, audio, USB devices, network interfaces, and disks. Also prints the full node configuration (compose files, prefixes, setup script, etc.).
 
-- If `log_dir` is set: output is captured silently and saved to `<log_dir>/<node_id>/config.log`. The saved path is printed to the console.
-- If `log_dir` is empty: all output is streamed live to stdout.
+- If `config_log_dir` is set: output is captured silently and saved to `<config_log_dir>/<node_id>.log`. The saved path is printed to the console.
+- If `config_log_dir` is empty: all output is streamed live to stdout.
 
 ```bash
 dockyman info              # all nodes
@@ -186,7 +186,8 @@ project:
   name: <string>               # Project name (required)
   dockyman_repo: <url>         # GitHub repo URL (required)
   dockyman_ref: <string>        # Tag or branch (optional, default: main)
-  log_dir: <path>              # Log directory (optional, see below)
+  container_log_dir: <path>    # Container logs directory (optional, see below)
+  config_log_dir: <path>       # Hardware/config logs directory (optional, see below)
   swarm:
     - <node>
     - <node>
@@ -199,7 +200,9 @@ project:
 | `name` | ✓ | Project name. |
 | `dockyman_repo` | ✓ | GitHub repository URL for this dockyman project. |
 | `dockyman_ref` | | Git tag or branch to track (defaults to `main`). |
-| `log_dir` | | Directory for all log files, relative to `dockyman.yaml` or absolute. Omit or leave empty to disable file logging (container logs go to stdout, hardware info to stdout). |
+| `container_log_dir` | | Directory for container logs, relative to `dockyman.yaml` or absolute. Omit or leave empty (default) to stream container logs to stdout. |
+| `config_log_dir` | | Directory for hardware/config logs, relative to `dockyman.yaml` or absolute. Omit or leave empty (default) to stream hardware info to stdout. |
+| `log_dir` | | **Deprecated.** Use `container_log_dir` and `config_log_dir` instead. When present, sets both directories for backward compatibility. |
 
 ### Node settings
 
@@ -224,13 +227,13 @@ Each entry in `swarm` describes one node.
 
 | File | When written | Contents |
 |---|---|---|
-| `<log_dir>/<node_id>/config.log` | `dockyman info`, `dockyman run` | Node configuration (compose files, env files, shell prefixes, setup script) + full hardware scan (OS, CPU, memory, GPU, audio, USB, network, disks). |
-| `<log_dir>/<node_id>/<service>.log` | `dockyman run` (when `log_dir` is set) | Live container log output for that service. |
+| `<config_log_dir>/<node_id>.log` | `dockyman info`, `dockyman run` | Node configuration (compose files, env files, shell prefixes, setup script) + full hardware scan (OS, CPU, memory, GPU, audio, USB, network, disks). |
+| `<container_log_dir>/<node_id>/<service>.log` | `dockyman run` (when `container_log_dir` is set) | Live container log output for that service. |
 
-When `log_dir` is empty or omitted:
-- Container logs are streamed to stdout.
-- `dockyman info` streams hardware output to stdout.
-- No files are written.
+All logging is **OFF by default**:
+- When `container_log_dir` is empty or omitted: container logs are streamed to stdout.
+- When `config_log_dir` is empty or omitted: `dockyman info` streams hardware output to stdout.
+- You can enable each type of logging independently or disable both.
 
 ## Contributing
 

--- a/docker/dockyman.yaml
+++ b/docker/dockyman.yaml
@@ -1,14 +1,19 @@
 project:
   name: my_project
   dockyman_repo: https://github.com/s4hri/dockyman
-  dockyman_ref: v4.0.0
+  dockyman_ref: v4.1.0
 
-  # Directory for log files (relative to this yaml file, or absolute).
-  # - Container logs: one file per service per node  → <log_dir>/<node_id>/<service>.log
-  # - Hardware info:  one file per node              → <log_dir>/<node_id>/config.log
-  # Leave empty or omit to disable all file logging (container logs go to stdout).
+  # ── Logging configuration ──────────────────────────────────────────────
+  # All logging is OFF by default. Enable each type independently:
+
+  # Container logs: one file per service per node → <container_log_dir>/<node_id>/<service>.log
+  # Leave empty or omit to disable (container logs go to stdout).
   # Can be overridden at runtime with: dockyman run --log-output <dir>
-  log_dir: ./logs
+  # container_log_dir: ./logs/containers
+
+  # Hardware/config logs: one file per node → <config_log_dir>/<node_id>.log
+  # Leave empty or omit to disable (hardware info prints to stdout).
+  # config_log_dir: ./logs/config
 
   swarm:
 

--- a/dockyman/cli.py
+++ b/dockyman/cli.py
@@ -85,6 +85,18 @@ def main(argv: list[str] | None = None) -> None:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    # Warn if the YAML-declared version doesn't match the installed one
+    # Normalize versions by stripping 'v' prefix for comparison
+    if __version__ != "unknown":
+        installed_norm = __version__.lstrip("v")
+        yaml_norm = project.dockyman_ref.lstrip("v")
+        if installed_norm != yaml_norm:
+            print(
+                f"\033[33mWARNING: dockyman.yaml declares dockyman_ref '{project.dockyman_ref}' "
+                f"but the installed version is '{__version__}'.\033[0m",
+                file=sys.stderr,
+            )
+
     dry = args.dry_run
     ok = True
 
@@ -95,7 +107,7 @@ def main(argv: list[str] | None = None) -> None:
         case "build":
             ok = build(project, dry_run=dry)
         case "run":
-            log_dir = args.log_output if args.log_output else (project.log_dir or None)
+            log_dir = args.log_output if args.log_output else (project.container_log_dir or None)
             ok = run(project, dry_run=dry, detach=args.detach,
                      log_dir=log_dir)
         case "down":

--- a/dockyman/config.py
+++ b/dockyman/config.py
@@ -59,7 +59,8 @@ class Project:
     dockyman_repo: str
     dockyman_ref: str
     swarm: List[Node]
-    log_dir: str = ""
+    container_log_dir: str = ""
+    config_log_dir: str = ""
 
     # Set after loading – absolute path to the dockyman.yaml directory.
     base_dir: str = ""
@@ -110,11 +111,23 @@ def load_config(config_path: str = "dockyman.yaml") -> Project:
         dockyman_repo=str(proj_raw["dockyman_repo"]),
         dockyman_ref=str(proj_raw.get("dockyman_ref", "main")),
         swarm=nodes,
-        log_dir=proj_raw.get("log_dir", ""),
+        container_log_dir=proj_raw.get("container_log_dir", ""),
+        config_log_dir=proj_raw.get("config_log_dir", ""),
     )
     project.base_dir = str(Path(base_dir).resolve())
-    # Resolve log_dir relative to the config file location
-    if project.log_dir:
-        project.log_dir = str((Path(project.base_dir) / project.log_dir).resolve())
+    
+    # Backward compatibility: if old 'log_dir' is present, use it for both
+    if "log_dir" in proj_raw and proj_raw["log_dir"]:
+        old_log_dir = proj_raw["log_dir"]
+        if not project.container_log_dir:
+            project.container_log_dir = old_log_dir
+        if not project.config_log_dir:
+            project.config_log_dir = old_log_dir
+    
+    # Resolve log directories relative to the config file location
+    if project.container_log_dir:
+        project.container_log_dir = str((Path(project.base_dir) / project.container_log_dir).resolve())
+    if project.config_log_dir:
+        project.config_log_dir = str((Path(project.base_dir) / project.config_log_dir).resolve())
 
     return project

--- a/dockyman/executor.py
+++ b/dockyman/executor.py
@@ -167,7 +167,7 @@ def run(project: Project, dry_run: bool = False, detach: bool = False,
     from .hardware import setup as hw_setup, detect_hardware as hw_detect
     with logger.quiet_mode():
         hw_setup(project, dry_run=dry_run)
-    if project.log_dir:
+    if project.config_log_dir:
         hw_detect(project, dry_run=dry_run, _show_header=False)
 
     # ── 1. Start containers (always detached) ────────────────────────────

--- a/dockyman/hardware.py
+++ b/dockyman/hardware.py
@@ -142,10 +142,10 @@ def detect_hardware(project: Project, *, dry_run: bool = False,
                     _init_log: bool = True, _show_header: bool = True) -> bool:
     """Detect hardware on all nodes in the swarm.
 
-    Output destination depends on ``project.log_dir``:
+    Output destination depends on ``project.config_log_dir``:
 
     - Set     → config section printed to console; hardware scan captured to
-                ``config.log`` silently.
+                ``<node_id>.log`` silently.
     - Not set → everything streamed live to stdout.
 
     *_show_header*: set False to suppress the "Hardware information" banner
@@ -156,11 +156,10 @@ def detect_hardware(project: Project, *, dry_run: bool = False,
     all_ok = True
     for node in project.swarm:
         node._project = project
-        to_stdout = not project.log_dir
-        if project.log_dir and _init_log:
-            node_log_dir = os.path.join(project.log_dir, node.node_id)
-            os.makedirs(node_log_dir, exist_ok=True)
-            log_path = os.path.join(node_log_dir, "config.log")
+        to_stdout = not project.config_log_dir
+        if project.config_log_dir and _init_log:
+            os.makedirs(project.config_log_dir, exist_ok=True)
+            log_path = os.path.join(project.config_log_dir, f"{node.node_id}.log")
             logger.init_log(log_path)
             logger.saved(log_path)
         logger.node_header(node.node_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "dockyman"
-version = "v4.0.0"
+version = "v4.1.0"
 description = "Orchestrate Docker Compose services across multiple machines."
 readme = "README.md"
 license = "MIT"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -125,7 +125,9 @@ class TestLoadConfig:
         f.write_text(self.FULL_YAML)
         project = load_config(str(f))
 
-        assert project.log_dir == str(tmp_path / "logs")
+        # Old log_dir backward-compat: should set both directories
+        assert project.container_log_dir == str(tmp_path / "logs")
+        assert project.config_log_dir == str(tmp_path / "logs")
         assert len(project.swarm) == 2
 
         local = project.swarm[0]

--- a/tests/test_log_dir.py
+++ b/tests/test_log_dir.py
@@ -1,4 +1,4 @@
-"""Tests for log_dir resolution in load_config."""
+"""Tests for logging directory resolution in load_config."""
 
 from __future__ import annotations
 
@@ -8,56 +8,95 @@ from pathlib import Path
 from dockyman.config import load_config
 
 
-def _yaml(log_dir_line: str) -> str:
+def _yaml(log_config: str) -> str:
     return textwrap.dedent(f"""\
         project:
           name: test
           dockyman_repo: https://github.com/youruser/dockyman
           dockyman_ref: v4.0.0
-          {log_dir_line}
+          {log_config}
           swarm:
             - node_id: manager
               compose_files: [compose.yaml]
     """)
 
 
-class TestLogDirResolution:
-    def test_relative_path_resolved_against_config_dir(self, tmp_path):
+class TestLogDirBackwardCompatibility:
+    """Test backward compatibility with old log_dir field."""
+    
+    def test_log_dir_sets_both_directories(self, tmp_path):
+        """Old log_dir field should set both container_log_dir and config_log_dir."""
         f = tmp_path / "dockyman.yaml"
         f.write_text(_yaml("log_dir: logs"))
         project = load_config(str(f))
-        assert project.log_dir == str(tmp_path / "logs")
+        expected = str(tmp_path / "logs")
+        assert project.container_log_dir == expected
+        assert project.config_log_dir == expected
 
-    def test_dotslash_relative_path_resolved(self, tmp_path):
-        f = tmp_path / "dockyman.yaml"
-        f.write_text(_yaml("log_dir: ./logs"))
-        project = load_config(str(f))
-        assert project.log_dir == str(tmp_path / "logs")
-
-    def test_absolute_path_kept_as_is(self, tmp_path):
+    def test_log_dir_absolute_path(self, tmp_path):
         abs_path = str(tmp_path / "custom" / "logs")
         f = tmp_path / "dockyman.yaml"
         f.write_text(_yaml(f"log_dir: {abs_path}"))
         project = load_config(str(f))
-        assert project.log_dir == abs_path
+        assert project.container_log_dir == abs_path
+        assert project.config_log_dir == abs_path
 
-    def test_empty_string_stays_empty(self, tmp_path):
-        """Empty log_dir disables all logging (no config.log, no container logs)."""
+    def test_log_dir_empty_disables_all(self, tmp_path):
+        """Empty log_dir disables all logging."""
         f = tmp_path / "dockyman.yaml"
         f.write_text(_yaml('log_dir: ""'))
         project = load_config(str(f))
-        assert project.log_dir == ""
+        assert project.container_log_dir == ""
+        assert project.config_log_dir == ""
 
-    def test_omitted_log_dir_defaults_to_empty(self, tmp_path):
+
+class TestSeparateLogDirectories:
+    """Test new separate container_log_dir and config_log_dir fields."""
+    
+    def test_separate_directories_resolved(self, tmp_path):
         f = tmp_path / "dockyman.yaml"
-        f.write_text(_yaml(""))  # no log_dir key at all
+        f.write_text(_yaml("""container_log_dir: logs/containers
+          config_log_dir: logs/config"""))
         project = load_config(str(f))
-        assert project.log_dir == ""
+        assert project.container_log_dir == str(tmp_path / "logs" / "containers")
+        assert project.config_log_dir == str(tmp_path / "logs" / "config")
+
+    def test_only_container_log_enabled(self, tmp_path):
+        f = tmp_path / "dockyman.yaml"
+        f.write_text(_yaml("container_log_dir: logs/containers"))
+        project = load_config(str(f))
+        assert project.container_log_dir == str(tmp_path / "logs" / "containers")
+        assert project.config_log_dir == ""
+
+    def test_only_config_log_enabled(self, tmp_path):
+        f = tmp_path / "dockyman.yaml"
+        f.write_text(_yaml("config_log_dir: logs/config"))
+        project = load_config(str(f))
+        assert project.container_log_dir == ""
+        assert project.config_log_dir == str(tmp_path / "logs" / "config")
+
+    def test_omitted_defaults_to_empty(self, tmp_path):
+        """No log directories specified means all logging off by default."""
+        f = tmp_path / "dockyman.yaml"
+        f.write_text(_yaml(""))  # no log config at all
+        project = load_config(str(f))
+        assert project.container_log_dir == ""
+        assert project.config_log_dir == ""
+
+    def test_new_fields_override_old_log_dir(self, tmp_path):
+        """New fields take precedence over old log_dir for backward compat."""
+        f = tmp_path / "dockyman.yaml"
+        f.write_text(_yaml("""log_dir: old_logs
+          container_log_dir: new_containers
+          config_log_dir: new_config"""))
+        project = load_config(str(f))
+        assert project.container_log_dir == str(tmp_path / "new_containers")
+        assert project.config_log_dir == str(tmp_path / "new_config")
 
     def test_nested_config_dir_resolves_correctly(self, tmp_path):
         sub = tmp_path / "project" / "config"
         sub.mkdir(parents=True)
         f = sub / "dockyman.yaml"
-        f.write_text(_yaml("log_dir: logs"))
+        f.write_text(_yaml("container_log_dir: logs"))
         project = load_config(str(f))
-        assert project.log_dir == str(sub / "logs")
+        assert project.container_log_dir == str(sub / "logs")


### PR DESCRIPTION
- Add version check between dockyman.yaml ref and installed version with yellow warning
- Replace single log_dir with separate container_log_dir and config_log_dir
- All logging now OFF by default, can be enabled independently
- Update config log path: <config_log_dir>/<node_id>.log (not in subdirectory)
- Container logs remain in: <container_log_dir>/<node_id>/<service>.log
- Maintain backward compatibility with old log_dir field
- Update tests with comprehensive coverage for new logging structure
- Update documentation to reflect all changes