### PR TITLE
Fix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,12 +141,23 @@ dockyman down
 
 ### `dockyman config`
 
-Print the resolved Compose configuration for each node (`docker compose config`).
+Print the resolved Compose configuration for each node (`docker compose config`), activating all profiles (build + run) defined for that node.
 
 ```bash
-dockyman config build      # activate only build profiles
-dockyman config run        # activate only run profiles
+dockyman config                          # all nodes, all profiles
+dockyman config --stage build            # build_shell_prefix + build_profiles
+dockyman config --stage run              # run_shell_prefix   + run_profiles
+dockyman config -n manager               # single node
+dockyman config -p build                 # only nodes that have the 'build' profile
+dockyman config -p build -p prod         # multiple profiles
+dockyman config --stage build -n manager # combine all filters
 ```
+
+| Option | Description |
+|---|---|
+| `--stage {build,run}` | Apply the settings for a specific stage: `build` uses `build_shell_prefix` + `build_profiles`; `run` uses `run_shell_prefix` + `run_profiles`. Default: merge both stages. |
+| `-n NODE`, `--node NODE` | Limit to a specific node ID. |
+| `-p PROFILE`, `--profile PROFILE` | Limit to this profile (can be repeated). Only profiles that are also declared on the node for the selected stage are activated. Default: all profiles for the stage. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ dockyman down
 Print the resolved Compose configuration for each node (`docker compose config`).
 
 ```bash
-dockyman config
+dockyman config build      # activate only build profiles
+dockyman config run        # activate only run profiles
 ```
 
 ---

--- a/dockyman/cli.py
+++ b/dockyman/cli.py
@@ -65,10 +65,17 @@ def main(argv: list[str] | None = None) -> None:
 
     # -- config ----------------------------------------------------------------
     config_parser = sub.add_parser("config", help="Show resolved compose config on all nodes.")
+    _add_node_arg(config_parser)
     config_parser.add_argument(
-        "config_profile_type", 
-        choices=["build", "run"], 
-        help="The profile type to activate for `docker compose config`"
+        "-p", "--profile",
+        dest="profiles", action="append", default=None, metavar="PROFILE",
+        help="Limit to this profile (can be repeated). Default: all profiles defined for each node.",
+    )
+    config_parser.add_argument(
+        "--stage",
+        choices=["build", "run"], default=None,
+        help="Show config for a specific stage: 'build' uses build_shell_prefix + build_profiles, "
+             "'run' uses run_shell_prefix + run_profiles. Default: merge both.",
     )
 
     # -- info ------------------------------------------------------------------
@@ -118,7 +125,10 @@ def main(argv: list[str] | None = None) -> None:
         case "down":
             ok = down(project, dry_run=dry)
         case "config":
-            ok = config(project, dry_run=dry, profile_type=args.config_profile_type)
+            ok = config(project, dry_run=dry,
+                        node_filter=args.node,
+                        profile_filter=args.profiles,
+                        stage=args.stage)
 
         # hardware info
         case "info":

--- a/dockyman/cli.py
+++ b/dockyman/cli.py
@@ -64,7 +64,12 @@ def main(argv: list[str] | None = None) -> None:
     sub.add_parser("down", help="Stop services on all nodes.")
 
     # -- config ----------------------------------------------------------------
-    sub.add_parser("config", help="Show resolved compose config on all nodes.")
+    config_parser = sub.add_parser("config", help="Show resolved compose config on all nodes.")
+    config_parser.add_argument(
+        "config_profile_type", 
+        choices=["build", "run"], 
+        help="The profile type to activate for `docker compose config`"
+    )
 
     # -- info ------------------------------------------------------------------
     info_parser = sub.add_parser("info", help="Detect hardware on all nodes.")
@@ -113,7 +118,7 @@ def main(argv: list[str] | None = None) -> None:
         case "down":
             ok = down(project, dry_run=dry)
         case "config":
-            ok = config(project, dry_run=dry)
+            ok = config(project, dry_run=dry, profile_type=args.config_profile_type)
 
         # hardware info
         case "info":

--- a/dockyman/config.py
+++ b/dockyman/config.py
@@ -39,9 +39,10 @@ class Node:
         parts: list[str] = []
         if self.docker_host:
             parts.append(f"DOCKER_HOST={self.docker_host}")
-        if command_type == "build" and self.build_shell_prefix.strip():
+            
+        if command_type in ["build", "config_build"] and self.build_shell_prefix.strip():
             parts.append(self.build_shell_prefix.strip())
-        elif command_type == "run" and self.run_shell_prefix.strip():
+        elif command_type in ["run", "config_run"] and self.run_shell_prefix.strip():
             parts.append(self.run_shell_prefix.strip())
         return " ".join(parts)
 

--- a/dockyman/executor.py
+++ b/dockyman/executor.py
@@ -55,8 +55,10 @@ def _build_compose_cmd(project: Project, node: Node, action: str, command_type: 
     """Build the full shell command string for a node.
 
     *command_type* selects the shell prefix, profiles, and extra CLI args:
-    ``"build"`` → ``build_shell_prefix`` + ``build_profiles`` + ``build_args``,
-    ``"run"``   → ``run_shell_prefix``   + ``run_profiles``   + ``run_args``.
+    ``"build"``        → ``build_shell_prefix`` + ``build_profiles`` + ``build_args``,
+    ``"run"``          → ``run_shell_prefix``   + ``run_profiles``   + ``run_args``,
+    ``"config_build"`` → ``build_profiles``,
+    ``"config_run"``   → ``run_profiles``.
 
     Set *include_extra_args* to False to include env vars and profiles
     but omit the extra CLI args (e.g. ``--remove-orphans``).
@@ -70,6 +72,12 @@ def _build_compose_cmd(project: Project, node: Node, action: str, command_type: 
     elif command_type == "run":
         profiles = node.run_profiles
         extra_args = node.run_args.strip()
+    elif command_type == "config_build":
+        profiles = node.build_profiles
+        extra_args = ""
+    elif command_type == "config_run":
+        profiles = node.run_profiles
+        extra_args = ""
     else:
         profiles = []
         extra_args = ""
@@ -287,8 +295,12 @@ def down(project: Project, dry_run: bool = False) -> bool:
     return all_ok
 
 
-def config(project: Project, dry_run: bool = False) -> bool:
+def config(project: Project, profile_type: str, dry_run: bool = False) -> bool:
     """Run ``docker compose config`` on every node to show resolved config.
+
+    Select profiles to activate using `profile_filter`:
+        - `profile_type`="build"     Activate only build profiles
+        - `profile_type`="run"       Activate only run profiles
 
     Returns True if all nodes resolved successfully.
     """
@@ -297,7 +309,7 @@ def config(project: Project, dry_run: bool = False) -> bool:
 
     for node in project.swarm:
         logger.node_header(node.node_id)
-        cmd = _build_compose_cmd(project, node, "config", command_type="run")
+        cmd = _build_compose_cmd(project, node, "config", command_type=f"config_{profile_type}")
         rc = _run_shell(cmd, dry_run=dry_run)
         if rc != 0:
             all_ok = False

--- a/dockyman/executor.py
+++ b/dockyman/executor.py
@@ -57,8 +57,8 @@ def _build_compose_cmd(project: Project, node: Node, action: str, command_type: 
     *command_type* selects the shell prefix, profiles, and extra CLI args:
     ``"build"``        → ``build_shell_prefix`` + ``build_profiles`` + ``build_args``,
     ``"run"``          → ``run_shell_prefix``   + ``run_profiles``   + ``run_args``,
-    ``"config_build"`` → ``build_shell_prefix`` +``build_profiles``,
-    ``"config_run"``   → ``run_shell_prefix``   +``run_profiles``.
+    ``"config_build"`` → ``build_shell_prefix`` + ``build_profiles``,
+    ``"config_run"``   → ``run_shell_prefix``   + ``run_profiles``.
 
     Set *include_extra_args* to False to include env vars and profiles
     but omit the extra CLI args (e.g. ``--remove-orphans``).

--- a/dockyman/executor.py
+++ b/dockyman/executor.py
@@ -298,9 +298,9 @@ def down(project: Project, dry_run: bool = False) -> bool:
 def config(project: Project, profile_type: str, dry_run: bool = False) -> bool:
     """Run ``docker compose config`` on every node to show resolved config.
 
-    Select profiles to activate using `profile_filter`:
-        - `profile_type`="build"     Activate only build profiles
-        - `profile_type`="run"       Activate only run profiles
+    Select profiles to activate using ``profile_type``:
+        - ``profile_type="build"``   Activate only build profiles
+        - ``profile_type="run"``     Activate only run profiles
 
     Returns True if all nodes resolved successfully.
     """

--- a/dockyman/executor.py
+++ b/dockyman/executor.py
@@ -51,7 +51,8 @@ def _run_shell(cmd: str, cwd: Optional[str] = None, dry_run: bool = False) -> in
 
 
 def _build_compose_cmd(project: Project, node: Node, action: str, command_type: str = "",
-                       include_extra_args: bool = True) -> str:
+                       include_extra_args: bool = True,
+                       profile_override: list[str] | None = None) -> str:
     """Build the full shell command string for a node.
 
     *command_type* selects the shell prefix, profiles, and extra CLI args:
@@ -59,6 +60,9 @@ def _build_compose_cmd(project: Project, node: Node, action: str, command_type: 
     ``"run"``          → ``run_shell_prefix``   + ``run_profiles``   + ``run_args``,
     ``"config_build"`` → ``build_shell_prefix`` + ``build_profiles``,
     ``"config_run"``   → ``run_shell_prefix``   + ``run_profiles``.
+
+    *profile_override*, when provided, replaces the profile list derived from
+    *command_type*.  Use this to pass a pre-filtered or pre-merged profile list.
 
     Set *include_extra_args* to False to include env vars and profiles
     but omit the extra CLI args (e.g. ``--remove-orphans``).
@@ -72,6 +76,15 @@ def _build_compose_cmd(project: Project, node: Node, action: str, command_type: 
     elif command_type == "run":
         profiles = node.run_profiles
         extra_args = node.run_args.strip()
+    elif command_type == "config":
+        # All profiles defined for the node, deduplicated, preserving order
+        seen: set[str] = set()
+        profiles = []
+        for p in node.build_profiles + node.run_profiles:
+            if p not in seen:
+                seen.add(p)
+                profiles.append(p)
+        extra_args = ""
     elif command_type == "config_build":
         profiles = node.build_profiles
         extra_args = ""
@@ -81,6 +94,9 @@ def _build_compose_cmd(project: Project, node: Node, action: str, command_type: 
     else:
         profiles = []
         extra_args = ""
+
+    if profile_override is not None:
+        profiles = profile_override
 
     cmd_parts = []
     if env_prefix:
@@ -295,21 +311,64 @@ def down(project: Project, dry_run: bool = False) -> bool:
     return all_ok
 
 
-def config(project: Project, profile_type: str, dry_run: bool = False) -> bool:
+def config(project: Project, dry_run: bool = False,
+           node_filter: str | None = None,
+           profile_filter: list[str] | None = None,
+           stage: str | None = None) -> bool:
     """Run ``docker compose config`` on every node to show resolved config.
 
-    Select profiles to activate using ``profile_type``:
-        - ``profile_type="build"``   Activate only build profiles
-        - ``profile_type="run"``     Activate only run profiles
+    Args:
+        node_filter:    When given, only process the node with this ID.
+        profile_filter: When given, only activate profiles from this list
+                        (intersected with each node's stage-appropriate profiles).
+                        When omitted, all relevant profiles for the node are used.
+        stage:          ``"build"`` → use ``build_shell_prefix`` + ``build_profiles``;
+                        ``"run"``   → use ``run_shell_prefix``   + ``run_profiles``;
+                        ``None``    → merge both (default).
 
-    Returns True if all nodes resolved successfully.
+    Returns True if all matched nodes resolved successfully.
     """
     logger.header(f"Resolved compose config for project '{project.name}' …")
     all_ok = True
 
-    for node in project.swarm:
+    nodes = project.swarm
+    if node_filter:
+        nodes = [n for n in nodes if n.node_id == node_filter]
+        if not nodes:
+            import sys as _sys
+            print(f"Error: no node with id '{node_filter}'", file=_sys.stderr)
+            return False
+
+    # Map stage to the command_type understood by _build_compose_cmd
+    command_type = f"config_{stage}" if stage else "config"
+
+    for node in nodes:
         logger.node_header(node.node_id)
-        cmd = _build_compose_cmd(project, node, "config", command_type=f"config_{profile_type}")
+
+        # Candidate profiles depend on the stage
+        if stage == "build":
+            candidate = node.build_profiles
+        elif stage == "run":
+            candidate = node.run_profiles
+        else:
+            # All profiles for the node, deduplicated, preserving order
+            seen: set[str] = set()
+            candidate = []
+            for p in node.build_profiles + node.run_profiles:
+                if p not in seen:
+                    seen.add(p)
+                    candidate.append(p)
+
+        # Optionally narrow down by the --profile filter
+        if profile_filter is not None:
+            allowed = set(profile_filter)
+            profiles: list[str] | None = [p for p in candidate if p in allowed]
+        else:
+            profiles = candidate
+
+        cmd = _build_compose_cmd(project, node, "config",
+                                 command_type=command_type,
+                                 profile_override=profiles)
         rc = _run_shell(cmd, dry_run=dry_run)
         if rc != 0:
             all_ok = False

--- a/dockyman/executor.py
+++ b/dockyman/executor.py
@@ -57,8 +57,8 @@ def _build_compose_cmd(project: Project, node: Node, action: str, command_type: 
     *command_type* selects the shell prefix, profiles, and extra CLI args:
     ``"build"``        → ``build_shell_prefix`` + ``build_profiles`` + ``build_args``,
     ``"run"``          → ``run_shell_prefix``   + ``run_profiles``   + ``run_args``,
-    ``"config_build"`` → ``build_profiles``,
-    ``"config_run"``   → ``run_profiles``.
+    ``"config_build"`` → ``build_shell_prefix`` +``build_profiles``,
+    ``"config_run"``   → ``run_shell_prefix``   +``run_profiles``.
 
     Set *include_extra_args* to False to include env vars and profiles
     but omit the extra CLI args (e.g. ``--remove-orphans``).

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -72,6 +72,22 @@ class TestBuildComposeCmd:
         assert "--profile build" in cmd
         assert "--profile extra" in cmd
 
+    def test_docker_config_build_profiles_added(self):
+        node = Node(node_id="n", compose_files=["compose.yaml"],
+                    build_profiles=["build", "build_extra"])
+        project = _make_project(nodes=[node])
+        cmd = _build_compose_cmd(project, node, "config", command_type="config_build")
+        assert "--profile build" in cmd
+        assert "--profile build_extra" in cmd
+
+    def test_docker_config_run_profiles_added(self):
+        node = Node(node_id="n", compose_files=["compose.yaml"],
+                    run_profiles=["run", "run_extra"])
+        project = _make_project(nodes=[node])
+        cmd = _build_compose_cmd(project, node, "config", command_type="config_run")
+        assert "--profile run" in cmd
+        assert "--profile run_extra" in cmd
+
     def test_run_extra_args_appended(self):
         node = Node(node_id="n", compose_files=["compose.yaml"],
                     run_args="--remove-orphans")


### PR DESCRIPTION
Fixed `dockyman config` that failed when `run_args` was not empty by removing `extra_args` when running `docker compose config` and adding profiles type selection:
- `dockyman config build`: Run `docker compose config` activating only build profiles
- `dockyman config run`: Run `docker compose config` activating only run profiles
